### PR TITLE
Add mobile drawer menu

### DIFF
--- a/src/components/template/Template_Menu.vue
+++ b/src/components/template/Template_Menu.vue
@@ -1,67 +1,107 @@
-<script setup>
-
+<script>
+export default {
+  name: 'Template_Menu',
+  data() {
+    return {
+      drawer: false,
+      menuItems: [
+        { title: 'پروفایل', icon: '@/assets/images/menu/profile.svg', to: { name: 'profile' } },
+        { title: 'اعلانات', icon: '@/assets/images/menu/notifications.svg', to: { name: 'notifications' } },
+        { title: 'پروژه ها', icon: '@/assets/images/menu/projects.svg', to: { name: 'projects' } },
+        { title: 'داشبورد', icon: '@/assets/images/menu/home.svg', to: { name: 'index' } },
+        { title: 'شماره ها', icon: '@/assets/images/menu/customers.svg', to: { name: 'customers' } },
+        { title: 'گزارشات', icon: '@/assets/images/menu/reports.svg', to: { name: 'reports' } },
+        { title: 'فاکتور ها', icon: '@/assets/images/menu/invoices.svg', to: { name: 'invoices' } }
+      ],
+      footerImages: [
+        { src: '@/assets/images/icons/customer.svg', alt: 'footer-1' },
+        { src: '@/assets/images/icons/profile.svg', alt: 'footer-2' }
+      ]
+    }
+  },
+  computed: {
+    isMobile() {
+      return this.$vuetify.display.smAndDown
+    }
+  },
+  methods: {
+    toggleDrawer() {
+      this.drawer = !this.drawer
+    },
+    closeDrawer() {
+      this.drawer = false
+    }
+  }
+}
 </script>
 
 <template>
-  <div class="footer">
-    <v-container>
-      <div class="footer-menu">
-        <v-row justify="center" class="footer-dock">
-          <div class="text-center footer-item-margin">
-            <router-link :to="{name: 'profile'}">
-              <img src="@/assets/images/menu/profile.svg" class="menu-svg" :class="{'menu-active' : this.$route.name === 'profile'}" alt="" />
-              <div class="text-white font-13 font-weight-600">
-                 پروفایل
-              </div>
-          </router-link>
-          </div>
-          <div class="text-center footer-item-margin">
-            <img src="@/assets/images/menu/notifications.svg" class="menu-svg" alt="">
-            <div class="text-white font-13 font-weight-600">
-               اعلانات
-            </div>
-          </div>
-          <div class="text-center footer-item-margin">
-            <img src="@/assets/images/menu/projects.svg" class="menu-svg" alt="">
-            <div class="text-white font-13 font-weight-600">
-               پروژه ها
-            </div>
-          </div>
-          <div class="text-center footer-item-margin">
-            <router-link :to="{name: 'index'}">
-              <img src="@/assets/images/menu/home.svg" class="menu-svg" :class="{'menu-active' : this.$route.name === 'index'}" alt="">
-              <div class="text-white font-13 font-weight-600">
-                داشبورد
-              </div>
-            </router-link>
-          </div>
-          <div class="text-center footer-item-margin">
-            <router-link :to="{name: 'customers'}">
-              <img src="@/assets/images/menu/customers.svg" class="menu-svg" :class="{'menu-active' : this.$route.name === 'customers'}" alt="">
-              <div class="text-white font-13 font-weight-600">
-                 شماره ها
-              </div>
-            </router-link>
-          </div>
-          <div class="text-center footer-item-margin">
-            <img src="@/assets/images/menu/reports.svg" class="menu-svg" alt="">
-            <div class="text-white font-13 font-weight-600">
-               گزارشات
-            </div>
-          </div>
-          <div class="text-center footer-item-margin">
-            <img src="@/assets/images/menu/invoices.svg" class="menu-svg" alt="">
-            <div class="text-white font-13 font-weight-600">
-               فاکتور ها
-            </div>
-          </div>
+  <div>
+    <!-- Mobile header toggle -->
+    <v-app-bar flat class="color-dark-bg d-sm-none">
+      <v-app-bar-nav-icon @click="toggleDrawer" />
+    </v-app-bar>
 
-        </v-row>
+    <!-- Mobile navigation drawer -->
+    <v-navigation-drawer
+      v-model="drawer"
+      location="start"
+      temporary
+      class="d-sm-none"
+    >
+      <v-list>
+        <v-list-item
+          v-for="item in menuItems"
+          :key="item.title"
+          :to="item.to"
+          @click="closeDrawer"
+        >
+          <template #prepend>
+            <v-img :src="item.icon" width="24" height="24" :alt="item.title" />
+          </template>
+          <v-list-item-title>{{ item.title }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+      <v-spacer></v-spacer>
+      <div class="pa-4 text-center">
+        <v-img
+          v-for="(img, index) in footerImages"
+          :key="index"
+          :src="img.src"
+          :alt="img.alt"
+          class="mb-2"
+          height="32"
+        />
       </div>
-    </v-container>
+    </v-navigation-drawer>
 
+    <!-- Desktop footer menu -->
+    <div class="footer" v-show="!isMobile">
+      <v-container>
+        <div class="footer-menu">
+          <v-row justify="center" class="footer-dock">
+            <div
+              v-for="item in menuItems"
+              :key="item.title"
+              class="text-center footer-item-margin"
+            >
+              <router-link :to="item.to" @click="closeDrawer">
+                <img
+                  :src="item.icon"
+                  class="menu-svg"
+                  :class="{ 'menu-active': $route.name === item.to.name }"
+                  :alt="item.title"
+                />
+                <div class="text-white font-13 font-weight-600">
+                  {{ item.title }}
+                </div>
+              </router-link>
+            </div>
+          </v-row>
+        </div>
+      </v-container>
+    </div>
   </div>
-
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add mobile-friendly navigation drawer to `Template_Menu.vue`
- hide footer menu on small screens
- provide header toggle button to open the drawer

## Testing
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ad0e3085c8331adb98d50b70ef509